### PR TITLE
Refine clear icon behavior based on `Select`'s `allowClear` prop

### DIFF
--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -41,9 +41,11 @@ export const Select = (props: SelectProps) => {
           <CaretDown size={14} data-testid="caret-down" weight="duotone" />
         )
       }
-      allowClear={{
-        clearIcon: <XCircle size={14} weight="duotone" />,
-      }}
+      allowClear={
+        props.allowClear
+          ? { clearIcon: <XCircle size={14} weight="duotone" /> }
+          : false
+      }
       showSearch={props.showSearch}
       onSearch={props.onSearch ? handleSearch : undefined}
       onFocus={() => {

--- a/src/components/select/__tests__/__snapshots__/select.test.tsx.snap
+++ b/src/components/select/__tests__/__snapshots__/select.test.tsx.snap
@@ -1,9 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Select should not render clear icon when allowClear is disabled 1`] = `
+<div>
+  <div
+    class="ant-select ant-select-outlined css-dev-only-do-not-override-ccdg5a ant-select-single ant-select-show-arrow"
+  >
+    <div
+      class="ant-select-selector"
+    >
+      <span
+        class="ant-select-selection-search"
+      >
+        <input
+          aria-autocomplete="list"
+          aria-controls="rc_select_TEST_OR_SSR_list"
+          aria-expanded="false"
+          aria-haspopup="listbox"
+          aria-owns="rc_select_TEST_OR_SSR_list"
+          autocomplete="off"
+          class="ant-select-selection-search-input"
+          id="rc_select_TEST_OR_SSR"
+          readonly=""
+          role="combobox"
+          style="opacity: 0;"
+          type="search"
+          unselectable="on"
+          value=""
+        />
+      </span>
+      <span
+        class="ant-select-selection-placeholder"
+      />
+    </div>
+    <span
+      aria-hidden="true"
+      class="ant-select-arrow"
+      style="user-select: none;"
+      unselectable="on"
+    >
+      <svg
+        data-testid="caret-down"
+        fill="currentColor"
+        height="14"
+        viewBox="0 0 256 256"
+        width="14"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M208,96l-80,80L48,96Z"
+          opacity="0.2"
+        />
+        <path
+          d="M215.39,92.94A8,8,0,0,0,208,88H48a8,8,0,0,0-5.66,13.66l80,80a8,8,0,0,0,11.32,0l80-80A8,8,0,0,0,215.39,92.94ZM128,164.69,67.31,104H188.69Z"
+        />
+      </svg>
+    </span>
+  </div>
+</div>
+`;
+
 exports[`Select should render correctly 1`] = `
 <div>
   <div
-    class="ant-select ant-select-outlined css-dev-only-do-not-override-ccdg5a ant-select-single ant-select-allow-clear ant-select-show-arrow"
+    class="ant-select ant-select-outlined css-dev-only-do-not-override-ccdg5a ant-select-single ant-select-show-arrow"
   >
     <div
       class="ant-select-selector"
@@ -121,7 +180,7 @@ exports[`Select should render with allowClear enabled 1`] = `
 exports[`Select should render with loading indicator 1`] = `
 <div>
   <div
-    class="ant-select ant-select-outlined css-dev-only-do-not-override-ccdg5a ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-loading"
+    class="ant-select ant-select-outlined css-dev-only-do-not-override-ccdg5a ant-select-single ant-select-show-arrow ant-select-loading"
   >
     <div
       class="ant-select-selector"
@@ -190,7 +249,7 @@ exports[`Select should render with loading indicator 1`] = `
 exports[`Select should render with options 1`] = `
 <div>
   <div
-    class="ant-select ant-select-outlined css-dev-only-do-not-override-ccdg5a ant-select-single ant-select-allow-clear ant-select-show-arrow"
+    class="ant-select ant-select-outlined css-dev-only-do-not-override-ccdg5a ant-select-single ant-select-show-arrow"
   >
     <div
       class="ant-select-selector"
@@ -249,7 +308,7 @@ exports[`Select should render with options 1`] = `
 exports[`Select should render with search enabled 1`] = `
 <div>
   <div
-    class="ant-select ant-select-outlined css-dev-only-do-not-override-ccdg5a ant-select-single ant-select-allow-clear ant-select-show-arrow ant-select-show-search"
+    class="ant-select ant-select-outlined css-dev-only-do-not-override-ccdg5a ant-select-single ant-select-show-arrow ant-select-show-search"
   >
     <div
       class="ant-select-selector"

--- a/src/components/select/__tests__/select.test.tsx
+++ b/src/components/select/__tests__/select.test.tsx
@@ -83,4 +83,20 @@ describe('Select', () => {
     )
     expect(container).toMatchSnapshot()
   })
+
+  it('should not render clear icon when allowClear is disabled', () => {
+    const { container } = render(
+      <Select
+        options={[
+          { label: 'Bronze Plan', value: 'bronze' },
+          { label: 'Silver Plan', value: 'silver' },
+          { label: 'Gold Plan', value: 'gold' },
+          { label: 'Platinum Plan', value: 'platinum' },
+        ]}
+      />
+    )
+    fireEvent.mouseOver(container.firstChild as Element)
+    expect(container.querySelector('[data-testid="clear-icon"]')).toBeFalsy()
+    expect(container).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
Updated the select component to conditionally render the clear icon only when the `allowClear` prop is set to true.