### PR TITLE
Adjust tickInterval type for better flexibility

### DIFF
--- a/src/components/barchart/BarChart.tsx
+++ b/src/components/barchart/BarChart.tsx
@@ -16,7 +16,7 @@ type BarChartProps = {
   series: Series[]
   min: number
   max: number | undefined | null
-  tickInterval: number
+  tickInterval: number | undefined | null
   tickFormat?: (value: number) => string
   xAxisTitle?: string
   yAxisTitle?: string


### PR DESCRIPTION
Updated the tickInterval prop type to allow for undefined or null values, enhancing flexibility in how the component can be used. This change accommodates scenarios where a tick interval may not be set, preventing potential errors and improving overall robustness.