### PR TITLE
Improve BarChart export options and default styling

### DIFF
--- a/src/components/barchart/BarChart.tsx
+++ b/src/components/barchart/BarChart.tsx
@@ -67,6 +67,12 @@ const BarChart = ({
     exporting: {
       ...exporting,
       enabled: false, // Ensure Highcharts' default export menu is hidden
+      chartOptions: {
+        series: series.map(() => ({
+          type: 'column',
+          color: '#253761', // --j2-blue-9
+        })),
+      },
     },
     title: {
       text: '',


### PR DESCRIPTION
Ensures the chart defaults to J2's color.

Exported chart image example (this is not the web app):

![chart (14)](https://github.com/user-attachments/assets/7b08aaea-06c4-4404-9580-2fff7886caf0)


