### PR TITLE
Enhances BarChart export options

### DIFF
--- a/src/components/barchart/BarChart.tsx
+++ b/src/components/barchart/BarChart.tsx
@@ -68,6 +68,18 @@ const BarChart = ({
       ...exporting,
       enabled: false, // Ensure Highcharts' default export menu is hidden
       chartOptions: {
+        // We still allow the user to override the defaults if desired
+        ...exporting?.chartOptions,
+        title: {
+          align: 'left',
+          text: exporting?.chartOptions?.title?.text,
+          style: {
+            fontSize: `${token.fontSize}px`,
+            fontFamily: token.fontFamily,
+            color: token.colorText,
+            ...exporting?.chartOptions?.title?.style,
+          },
+        },
         series: series.map(() => ({
           type: 'column',
           color: '#253761', // --j2-blue-9
@@ -75,7 +87,7 @@ const BarChart = ({
       },
     },
     title: {
-      text: '',
+      text: '', // The title is usually defined outside of the chart options, so we essentially hide it
     },
     xAxis: {
       categories: categories,


### PR DESCRIPTION
Allows customization of chart title styling within export options,
aligning it left and applying specific text styling. Retains ability
to override default export menu settings while keeping it hidden.

![chart (6).png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9Nr9Q3wukfsA6vZ9Rwy0/99b4e771-6735-48d2-8912-f1a18e545163.png)

