### PR TITLE
Adds bordered prop to Collapse component

### DIFF
--- a/src/components/collapse/Collapse.stories.ts
+++ b/src/components/collapse/Collapse.stories.ts
@@ -29,6 +29,9 @@ const meta = {
       control: 'radio',
       options: ['start', 'end'],
     },
+    bordered: {
+      control: 'boolean',
+    },
   },
 } satisfies Meta<typeof Collapse>
 
@@ -40,5 +43,6 @@ export const Default: Story = {
     items: items,
     defaultActiveKey: ['value-based-care'],
     expandIconPosition: 'end',
+    bordered: true,
   },
 }

--- a/src/components/collapse/Collapse.tsx
+++ b/src/components/collapse/Collapse.tsx
@@ -11,6 +11,7 @@ export type Props = CollapseProps & {
 const Collapse = ({
   defaultActiveKey,
   expandIconPosition,
+  bordered,
   ...props
 }: Props) => {
   return (
@@ -18,6 +19,7 @@ const Collapse = ({
       {...props}
       defaultActiveKey={defaultActiveKey}
       expandIconPosition={expandIconPosition}
+      bordered={bordered}
       expandIcon={({ isActive }) => (
         <CaretDown
           size={14}


### PR DESCRIPTION
Introduces a 'bordered' property for the Collapse component
to enhance visual styling control in its usage.
Updates storybook to demonstrate the new property.

![Screenshot 2024-11-20 at 6.03.04 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9Nr9Q3wukfsA6vZ9Rwy0/c4c8b62b-4b0b-4099-a15a-e01a2470cfde.png)

