### PR TITLE
MKT-586: Create Providers table (Overlap)

### DIFF
--- a/src/components/table/Table.module.css
+++ b/src/components/table/Table.module.css
@@ -1,4 +1,4 @@
-.bordered :global(.ant-table-cell) {
+.bordered :global(.ant-table-cell:not(.ant-table-cell-fix-left-last)) {
   border-left: none !important;
   border-right: none !important;
 }


### PR DESCRIPTION
[Jira link](https://j2health.atlassian.net/browse/MKT-586)

This makes the right-most left-fixed column have a right border as desired by the design:

<img width="2047" alt="image" src="https://github.com/user-attachments/assets/3f2a97a8-e343-4ba5-84e1-6f687b0be195" />
