### PR TITLE
MKT-628: Create Providers table (Marketability)

### DIFF
--- a/src/components/popover/Popover.module.css
+++ b/src/components/popover/Popover.module.css
@@ -7,3 +7,10 @@
   font-weight: var(--j2-font-weight-strong);
   line-height: var(--j2-line-height-heading-4);
 }
+
+.popoverHeader {
+  box-shadow: 0 2px 4px rgb(0 0 0 / 0.05);
+  border-radius: var(--j2-border-radius) var(--j2-border-radius) 0 0;
+
+  font-weight: bold;
+}

--- a/src/components/popover/Popover.stories.tsx
+++ b/src/components/popover/Popover.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { Popover } from './Popover'
+import { Popover, PopoverHeader } from './Popover'
 
 const meta = {
   title: 'Components/Popover',
@@ -33,9 +33,42 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
-    title: 'Did you know?',
     content: (
       <div>
+        <p>
+          <strong>CMS (Centers for Medicare & Medicaid Services)</strong>{' '}
+          oversees the nation’s major healthcare programs.
+        </p>
+        <p> Pretty important, right?'</p>
+      </div>
+    ),
+    trigger: 'hover',
+    children: <span>Trigger to learn about CMS</span>,
+  },
+}
+
+export const WithHeader: Story = {
+  args: {
+    content: (
+      <div className="-m-6">
+        <PopoverHeader title="Did you know?" />
+        <p>
+          <strong>CMS (Centers for Medicare & Medicaid Services)</strong>{' '}
+          oversees the nation’s major healthcare programs.
+        </p>
+        <p> Pretty important, right?'</p>
+      </div>
+    ),
+    trigger: 'hover',
+    children: <span>Trigger to learn about CMS</span>,
+  },
+}
+
+export const Closeable: Story = {
+  args: {
+    content: (
+      <div className="-m-6">
+        <PopoverHeader title="Did you know?" onClose={() => {}} />
         <p>
           <strong>CMS (Centers for Medicare & Medicaid Services)</strong>{' '}
           oversees the nation’s major healthcare programs.

--- a/src/components/popover/Popover.tsx
+++ b/src/components/popover/Popover.tsx
@@ -1,17 +1,53 @@
-import { Popover as AntdPopover, PopoverProps } from 'antd'
+import { Popover as AntdPopover, PopoverProps as AntdPopoverProps } from 'antd'
+import cx from 'classnames'
 import styles from './Popover.module.css'
-export type Props = Expand<PopoverProps>
 
-const Popover = ({ children, placement = 'top', ...props }: Props) => {
+type _Props = AntdPopoverProps & {
+  contentPadding?: boolean
+}
+
+export type PopoverProps = Expand<_Props>
+
+const Popover = ({
+  children,
+  placement = 'top',
+  contentPadding = true,
+  content,
+  ...props
+}: PopoverProps) => {
   return (
     <AntdPopover
       overlayClassName={styles.j2Popover}
       {...props}
       placement={placement}
+      content={() => {
+        if (!contentPadding) {
+          return (
+            <div className="-m-6">
+              {typeof content == 'function' ? content() : content}
+            </div>
+          )
+        }
+
+        return typeof content == 'function' ? content() : content
+      }}
     >
       {children}
     </AntdPopover>
   )
 }
 
-export { Popover }
+const PopoverHeader = ({ title }: { title: string }) => {
+  return (
+    <div
+      className={cx(
+        'py-2 px-3 items-center flex justify-between',
+        styles.popoverHeader
+      )}
+    >
+      {title}
+    </div>
+  )
+}
+
+export { Popover, PopoverHeader }

--- a/src/components/popover/index.tsx
+++ b/src/components/popover/index.tsx
@@ -1,1 +1,1 @@
-export { Popover } from './Popover'
+export * from './Popover'

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -3,20 +3,21 @@ import cx from 'classnames'
 
 import s from './Table.module.css'
 
-type MergedProps = TableProps & {
+type MergedProps<T> = TableProps<T> & {
   verticalBorders?: boolean
 }
 
-type Props = Expand<MergedProps>
+type Props<T> = Expand<MergedProps<T>>
 
-const Table = ({ verticalBorders, ...props }: Props) => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Table = <T = any,>({ verticalBorders, ...props }: Props<T>) => {
   return (
     <div
       className={cx(props.className, {
         [s.bordered]: props.bordered && !verticalBorders,
       })}
     >
-      <AntdTable {...props} />
+      <AntdTable<T> {...props} />
     </div>
   )
 }


### PR DESCRIPTION
[Jira link](https://j2health.atlassian.net/browse/MKT-628)

I disabled the padding in the example in storybook because it is probably common to need to disable the padding in a popover that uses this header, kinda a toss-up if I were to add it 

<img width="1302" alt="image" src="https://github.com/user-attachments/assets/a3ceba0a-d216-4ab4-9667-017c3c6d45fe" />

<img width="1229" alt="image" src="https://github.com/user-attachments/assets/1773b51c-d94c-45ce-b476-cb2389b5c5f7" />
