### PR TITLE
MKT-663: Compare Page - Overall Design Feedback

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,7 +27,9 @@ export default [
       'react-refresh': reactRefresh,
     },
     rules: {
-      'import/no-default-export': 'error', // Enforce named exports
+      'import/no-default-export': 'error',
+      'react/prop-types': 'off',
+      'react/display-name': 'off',
     },
   },
 ]

--- a/src/components/barchart/BarChart.tsx
+++ b/src/components/barchart/BarChart.tsx
@@ -3,6 +3,7 @@ import * as Highcharts from 'highcharts'
 import HighchartsReact from 'highcharts-react-official'
 import styles from './chart.module.css'
 import { renderToString } from 'react-dom/server'
+import accessibilityModule from 'highcharts/modules/accessibility'
 import exportingModule from 'highcharts/modules/exporting'
 import offlineExporting from 'highcharts/modules/offline-exporting'
 
@@ -48,6 +49,7 @@ const BarChart = ({
     exportingModule(Highcharts)
     offlineExporting(Highcharts)
   }
+  accessibilityModule(Highcharts)
 
   const { token } = theme.useToken()
 
@@ -66,9 +68,8 @@ const BarChart = ({
     },
     exporting: {
       ...exporting,
-      enabled: false, // Ensure Highcharts' default export menu is hidden
+      enabled: false,
       chartOptions: {
-        // We still allow the user to override the defaults if desired
         ...exporting?.chartOptions,
         title: {
           align: 'left',
@@ -87,7 +88,7 @@ const BarChart = ({
       },
     },
     title: {
-      text: '', // The title is usually defined outside of the chart options, so we essentially hide it
+      text: '',
     },
     xAxis: {
       categories: categories,

--- a/src/components/spinner/Spinner.tsx
+++ b/src/components/spinner/Spinner.tsx
@@ -5,6 +5,7 @@ import ProgressCircle from '../../svgs/ProgressCircle.svg?react'
 
 type SpinnerProps = {
   size?: number
+  className?: string
 }
 
 const SpinIcon = ({ height, width }: { height?: number; width?: number }) => {
@@ -13,6 +14,11 @@ const SpinIcon = ({ height, width }: { height?: number; width?: number }) => {
   )
 }
 
-export const Spinner = ({ size = 80 }: SpinnerProps) => {
-  return <Spin indicator={<SpinIcon height={size} width={size} />} />
+export const Spinner = ({ size = 80, className }: SpinnerProps) => {
+  return (
+    <Spin
+      className={className}
+      indicator={<SpinIcon height={size} width={size} />}
+    />
+  )
 }

--- a/src/components/table/Table.module.css
+++ b/src/components/table/Table.module.css
@@ -33,7 +33,6 @@
   border-right: none !important;
 }
 
-:global(.ant-spin-container.ant-spin-blur) th {
-  min-width: 160px;
-  width: 160px;
+:global(.ant-spin-container.ant-spin-blur) th :global(.ant-table-column-title) {
+  visibility: hidden;
 }

--- a/src/components/table/Table.module.css
+++ b/src/components/table/Table.module.css
@@ -32,3 +32,8 @@
   border-start-end-radius: var(--j2-border-radius);
   border-right: none !important;
 }
+
+:global(.ant-spin-container.ant-spin-blur) th {
+  min-width: 160px;
+  width: 160px;
+}

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -14,7 +14,11 @@ type MergedProps<T> = TableProps<T> & {
 
 type Props<T> = Expand<MergedProps<T>>
 
-export const defaultSortIcon = ({ sortOrder }: { sortOrder: 'ascend' | 'descend' | null }) => {
+export const defaultSortIcon = ({
+  sortOrder,
+}: {
+  sortOrder: 'ascend' | 'descend' | null
+}) => {
   if (sortOrder == 'ascend') {
     return <CaretUp />
   } else if (sortOrder == 'descend') {
@@ -73,9 +77,11 @@ const Table = <T = any,>({ verticalBorders, ...props }: Props<T>) => {
   )
 }
 
-type ColumnProps<T extends AnyObject> = Expand<ComponentProps<typeof AntdTable.Column<T>>>
+type ColumnProps<T extends AnyObject> = Expand<
+  ComponentProps<typeof AntdTable.Column<T>>
+>
 
-Table.Column = <T extends AnyObject,>(props: ColumnProps<T>) => {
+Table.Column = <T extends AnyObject>(props: ColumnProps<T>) => {
   return <AntdTable.Column<T> {...props} sortIcon={defaultSortIcon} />
 }
 Table.Summary = AntdTable.Summary

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -1,28 +1,83 @@
-import { Table as AntdTable, TableProps } from 'antd'
+import { Table as AntdTable, SpinProps, TableProps } from 'antd'
 import cx from 'classnames'
 
 import s from './Table.module.css'
+import { Spinner } from '../spinner'
+import { CaretDown, CaretUp, CaretUpDown } from '@phosphor-icons/react'
+import { ComponentProps } from 'react'
+import { AnyObject } from 'antd/es/_util/type'
 
 type MergedProps<T> = TableProps<T> & {
   verticalBorders?: boolean
+  columns?: TableProps<T>['columns']
 }
 
 type Props<T> = Expand<MergedProps<T>>
 
+export const defaultSortIcon = ({ sortOrder }: { sortOrder: 'ascend' | 'descend' | null }) => {
+  if (sortOrder == 'ascend') {
+    return <CaretUp />
+  } else if (sortOrder == 'descend') {
+    return <CaretDown />
+  }
+
+  return <CaretUpDown />
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const Table = <T = any,>({ verticalBorders, ...props }: Props<T>) => {
+  const defaultLoadingProps: SpinProps = {
+    indicator: <Spinner className="!w-fit !h-fit !mx-0 translate-x-[-50%]" />,
+    tip: (
+      <div className="mt-20">
+        <h4>Loading this chart</h4>
+        <span className="text-lg">Please wait a moment</span>
+      </div>
+    ),
+  }
+
+  const loading: SpinProps | boolean | undefined =
+    typeof props.loading == 'object'
+      ? {
+          ...props.loading,
+          ...defaultLoadingProps,
+        }
+      : props.loading && defaultLoadingProps
+
+  const columns = props.columns?.map((column) => ({
+    ...column,
+    sortIcon: defaultSortIcon,
+  }))
+
   return (
     <div
       className={cx(props.className, {
         [s.bordered]: props.bordered && !verticalBorders,
       })}
     >
-      <AntdTable<T> {...props} />
+      <AntdTable<T>
+        showSorterTooltip={{ target: 'sorter-icon' }}
+        {...props}
+        loading={loading}
+        columns={columns}
+        rowKey={(record) => JSON.stringify(record)}
+        locale={{
+          emptyText: (
+            <div
+              style={{ height: props.scroll?.y || 400, width: 'content-fit' }}
+            />
+          ),
+        }}
+      />
     </div>
   )
 }
 
-Table.Column = AntdTable.Column
+type ColumnProps<T extends AnyObject> = Expand<ComponentProps<typeof AntdTable.Column<T>>>
+
+Table.Column = <T extends AnyObject,>(props: ColumnProps<T>) => {
+  return <AntdTable.Column<T> {...props} sortIcon={defaultSortIcon} />
+}
 Table.Summary = AntdTable.Summary
 
 export type { TableColumnType } from 'antd'

--- a/src/components/table/__tests__/__snapshots__/table.test.tsx.snap
+++ b/src/components/table/__tests__/__snapshots__/table.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`Table should render correctly 1`] = `
                   >
                     <tr
                       class="ant-table-row ant-table-row-level-0"
+                      data-row-key="{"carrier":"aetna"}"
                     >
                       <td
                         class="ant-table-cell"

--- a/src/components/table/__tests__/table.test.tsx
+++ b/src/components/table/__tests__/table.test.tsx
@@ -7,6 +7,7 @@ describe('Table', () => {
       <Table
         columns={[{ dataIndex: 'carrier', title: 'Carrier' }]}
         dataSource={[{ carrier: 'aetna' }]}
+        rowKey="carrier"
       />
     )
     expect(container).toMatchSnapshot()


### PR DESCRIPTION
[Jira link](https://j2health.atlassian.net/browse/MKT-663)

This PR does a few things:

- Adds support for the `loading` prop to be used in the table
- *!important* you need to use the `loading` prop for sorting to work properly. If you unmount the table when the data is loading to display some other loading experience, then the sorting state in the table will be broken
- Fixes sort icons in the table to use the phosphor icons
- Fixes sort order icons not showing up/down when sorting on a specific column
- Fixes tooltip in the table that would show the incorrect direction of sorting 
- Makes the empty text height configurable along with the height of the container when there's data as well so that the table height doesn't bounce around when loading new data
- Updates some tests to remove some `console.error`s when running tests 

I left a comment in the commit too, but the primary way it fixes a lot of these things relating to the sort order not appearing correct (although it actually does operate normally) is by enabling the usage of the `loading` prop instead of unmounting and remounting the `<Table />` component as we do now on the network-intel-dashboard side. There will be an accompanying PR there too to remove the usage of those `<Loading />` components for table views in favor of this `loading` prop 

<img width="1910" alt="image" src="https://github.com/user-attachments/assets/c4e7959a-e820-4580-a15f-edb6dfd090c7" />
