### PR TITLE
Faith/mkt 634 extend composite filtering to plans tab

### DIFF
--- a/src/components/filterform/FilterInput.tsx
+++ b/src/components/filterform/FilterInput.tsx
@@ -13,6 +13,7 @@ type SelectValueInputConfig = {
 type NumberValueInputConfig = {
   type: 'number'
   inputCount: number
+  numberOptions: { max: number; min: number; step: number }
 }
 
 type TextValueInputConfig = {
@@ -166,6 +167,7 @@ const ValueInput = ({
                   value={values?.[index]}
                   className="basis-1/2"
                   size={size}
+                  {...valueInputConfig.numberOptions}
                 />
               </React.Fragment>
             )

--- a/src/components/filterform/FilterInput.tsx
+++ b/src/components/filterform/FilterInput.tsx
@@ -13,7 +13,7 @@ type SelectValueInputConfig = {
 type NumberValueInputConfig = {
   type: 'number'
   inputCount: number
-  numberOptions: { max: number; min: number; step: number }
+  numberOptions?: { max: number; min: number; step: number }
 }
 
 type TextValueInputConfig = {
@@ -167,7 +167,7 @@ const ValueInput = ({
                   value={values?.[index]}
                   className="basis-1/2"
                   size={size}
-                  {...valueInputConfig.numberOptions}
+                  {...(valueInputConfig.numberOptions ?? {})}
                 />
               </React.Fragment>
             )

--- a/src/components/filterform/types.ts
+++ b/src/components/filterform/types.ts
@@ -16,13 +16,15 @@ export type FilterGroup = {
 }
 
 export type FilterType = 'select' | 'number' | 'text'
+export type SelectOptionsType = { label: string; value: string }[]
+export type NumberOptionsType = { max: number; min: number; step: number }
 
 export type FilterConfig = {
   label: string
   field: string
   type: FilterType
   disabled?: boolean
-  options?: { label: string; value: string }[]
+  options?: SelectOptionsType | NumberOptionsType
 }
 
 export type Operator =

--- a/src/components/filterform/useFilterField.tsx
+++ b/src/components/filterform/useFilterField.tsx
@@ -62,7 +62,7 @@ type SelectValueInputConfig = {
 type NumberValueInputConfig = {
   type: 'number'
   inputCount: number
-  numberOptions: { max: number; min: number; step: number }
+  numberOptions?: { max: number; min: number; step: number }
 }
 
 type TextValueInputConfig = {

--- a/src/components/filterform/useFilterField.tsx
+++ b/src/components/filterform/useFilterField.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react'
-import { FilterConfig, FilterType, FormFilter, Operator } from './types'
+import {
+  FilterConfig,
+  FilterType,
+  FormFilter,
+  NumberOptionsType,
+  Operator,
+  SelectOptionsType,
+} from './types'
 import { validateFormFilter } from './filterHelpers'
 export type UseFilterFieldInputs = {
   filterConfigs: FilterConfig[]
@@ -55,6 +62,7 @@ type SelectValueInputConfig = {
 type NumberValueInputConfig = {
   type: 'number'
   inputCount: number
+  numberOptions: { max: number; min: number; step: number }
 }
 
 type TextValueInputConfig = {
@@ -92,7 +100,7 @@ const buildValueInputConfig = (
 
     return {
       type: 'select',
-      valueOptions: config.options || [],
+      valueOptions: (config.options as SelectOptionsType) || [],
     }
   }
 
@@ -102,6 +110,7 @@ const buildValueInputConfig = (
     return {
       type: 'number',
       inputCount: operator === 'inRange' ? 2 : 1,
+      numberOptions: config.options as NumberOptionsType,
     }
   }
 

--- a/src/components/inputnumber/InputNumber.tsx
+++ b/src/components/inputnumber/InputNumber.tsx
@@ -4,12 +4,25 @@ import styles from './InputNumber.module.css'
 import { CaretDown, CaretUp } from '@phosphor-icons/react'
 type Props = Expand<InputNumberProps> & {
   name: string
+  max?: number
+  min?: number
+  step?: number
 }
 
-export const InputNumber = ({ size = 'large', name, ...props }: Props) => {
+export const InputNumber = ({
+  size = 'large',
+  step = 1,
+  name,
+  max,
+  min,
+  ...props
+}: Props) => {
   return (
     <FormikInputNumber
       name={name}
+      max={max}
+      min={min}
+      step={step}
       className={cx(styles.j2InputNumber, props.className)}
       upHandler={<CaretUp weight="bold" size={12} />}
       downHandler={<CaretDown weight="bold" size={12} />}


### PR DESCRIPTION
[MKT-634](https://j2health.atlassian.net/browse/MKT-634)

This is kinda just for the CMS rating filtering :) 

Adds the option to pass in values for `min`, `max`, and `step` (increment) values for number inputs. This follows the same way that select inputs are receiving an array of { label + value } for the dropdown options. If not passed in, the `step` value defaults to 1 and max and min are ignored. The number options also are optional so that existing/future number inputs don't need to specify these settings.

<img width="1023" alt="Screenshot 2025-01-27 at 4 24 07 PM" src="https://github.com/user-attachments/assets/2927ca0b-541a-471c-bf8b-6112669f3542" />


[MKT-634]: https://j2health.atlassian.net/browse/MKT-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ