### PR TITLE
MKT-636: Support export of Plans table and chart

### DIFF
--- a/src/components/barchart/BarChart.tsx
+++ b/src/components/barchart/BarChart.tsx
@@ -76,7 +76,7 @@ const BarChart = ({
           text: exporting?.chartOptions?.title?.text,
           style: {
             fontSize: `${token.fontSize}px`,
-            fontFamily: token.fontFamily,
+            fontFamily: 'sans-serif',
             color: token.colorText,
             ...exporting?.chartOptions?.title?.style,
           },


### PR DESCRIPTION
[Jira link](https://j2health.atlassian.net/browse/MKT-636)

The font we use for Rubik is a woff2 font, I think highcharts needs a desktop font in order to be able to rasterize the png so it needs like a ttf font or something. I couldn't find a ttf file for Rubik so instead making it sans-serif seems okay 

Before:

![chart (10)](https://github.com/user-attachments/assets/e4eddd1b-ec22-4a87-b4aa-b7c520b7112b)

After:

![chart (13)](https://github.com/user-attachments/assets/b2b7b9b2-0e6e-49b6-b7be-0d2bc8e91e9e)
