### PR TITLE
Faith/mkt 634 extend composite filtering to plans tab

### DIFF
--- a/src/components/filterform/FilterInput.tsx
+++ b/src/components/filterform/FilterInput.tsx
@@ -13,7 +13,11 @@ type SelectValueInputConfig = {
 type NumberValueInputConfig = {
   type: 'number'
   inputCount: number
+<<<<<<< HEAD
   numberOptions?: { max: number; min: number; step: number }
+=======
+  numberOptions: { max: number; min: number; step: number }
+>>>>>>> 7c318ab (updates for min/max/step values for filter form numeric fields)
 }
 
 type TextValueInputConfig = {

--- a/src/components/filterform/FilterInput.tsx
+++ b/src/components/filterform/FilterInput.tsx
@@ -13,11 +13,7 @@ type SelectValueInputConfig = {
 type NumberValueInputConfig = {
   type: 'number'
   inputCount: number
-<<<<<<< HEAD
   numberOptions?: { max: number; min: number; step: number }
-=======
-  numberOptions: { max: number; min: number; step: number }
->>>>>>> 7c318ab (updates for min/max/step values for filter form numeric fields)
 }
 
 type TextValueInputConfig = {

--- a/src/components/filterform/useFilterField.tsx
+++ b/src/components/filterform/useFilterField.tsx
@@ -139,6 +139,7 @@ const filterFieldReducer = (
 
       const newFilter = {
         ...state.filter,
+        type: config.type,
         field: action.payload,
         operator: operatorOptions[0].value,
         values: [],


### PR DESCRIPTION
There was a bug where the types of form inputs were being set by the first/previous fields in the filter form. This was causing an issue if number was before text and then not allowing non-numeric values to be input in the form. 