### PR TITLE
MKT-673: Support export of Providers table (Compare - Overlap)

### DIFF
--- a/src/components/table/Table.module.css
+++ b/src/components/table/Table.module.css
@@ -33,6 +33,7 @@
   border-right: none !important;
 }
 
-:global(.ant-spin-container.ant-spin-blur) th :global(.ant-table-column-title) {
+:global(.ant-spin-container.ant-spin-blur) th :global(.ant-table-column-title),
+:global(.ant-spin-container.ant-spin-blur) th svg {
   visibility: hidden;
 }


### PR DESCRIPTION
[Jira link](https://j2health.atlassian.net/browse/MKT-673)

This at least hides the arrows as well while the page is loading

![image](https://github.com/user-attachments/assets/5159b076-c33f-46d1-9530-f5f7988504c6)
