### PR TITLE
MKT-692: Add close function to notification hook

### DIFF
--- a/src/components/notification/useNotification.tsx
+++ b/src/components/notification/useNotification.tsx
@@ -9,6 +9,7 @@ import {
   XCircle,
 } from '@phosphor-icons/react'
 import cx from 'classnames'
+import React from 'react'
 
 type NotificationType = 'success' | 'info' | 'warning' | 'error'
 
@@ -61,5 +62,9 @@ export const useNotification = () => {
     })
   }
 
-  return { openNotification, contextHolder }
+  const closeNotification = (key?: React.Key) => {
+    api.destroy(key)
+  }
+
+  return { openNotification, closeNotification, contextHolder }
 }


### PR DESCRIPTION
Makes the destroy (close) method available to use when adding an additional acknowledge/close button to a notification component 
