### PR TITLE
Suppress console warnings from tooltip and popover

### DIFF
--- a/src/components/navMenu/__tests__/__snapshots__/navMenu.test.tsx.snap
+++ b/src/components/navMenu/__tests__/__snapshots__/navMenu.test.tsx.snap
@@ -21,16 +21,18 @@ exports[`NavMenu should render correctly 1`] = `
             <test-file-stub />
             <test-file-stub />
           </a>
-          <button
-            class="ant-btn css-dev-only-do-not-override-tpassh ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-icon-only toggle-button"
-            type="button"
-          >
-            <span
-              class="ant-btn-icon"
+          <div>
+            <button
+              class="ant-btn css-dev-only-do-not-override-tpassh ant-btn-text ant-btn-color-default ant-btn-variant-text ant-btn-icon-only toggle-button"
+              type="button"
             >
-              <test-file-stub />
-            </span>
-          </button>
+              <span
+                class="ant-btn-icon"
+              >
+                <test-file-stub />
+              </span>
+            </button>
+          </div>
         </div>
       </div>
       <div

--- a/src/components/popover/Popover.tsx
+++ b/src/components/popover/Popover.tsx
@@ -32,7 +32,7 @@ const Popover = ({
         return typeof content == 'function' ? content() : content
       }}
     >
-      {children}
+      <div>{children}</div>
     </AntdPopover>
   )
 }

--- a/src/components/popover/__tests__/__snapshots__/popover.test.tsx.snap
+++ b/src/components/popover/__tests__/__snapshots__/popover.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`Popover should render correctly 1`] = `
 <div>
-  <span>
+  <div>
     Aetna
-  </span>
+  </div>
 </div>
 `;

--- a/src/components/tooltip/Tooltip.tsx
+++ b/src/components/tooltip/Tooltip.tsx
@@ -5,7 +5,7 @@ export type Props = Expand<TooltipProps>
 const Tooltip = ({ children, placement = 'top', ...props }: Props) => {
   return (
     <AntdTooltip {...props} placement={placement}>
-      {children}
+      <div>{children}</div>
     </AntdTooltip>
   )
 }

--- a/src/components/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
+++ b/src/components/tooltip/__tests__/__snapshots__/tooltip.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`Tooltip should render correctly 1`] = `
 <div>
-  <span>
+  <div>
     Aetna
-  </span>
+  </div>
 </div>
 `;


### PR DESCRIPTION

<img width="1087" alt="Screenshot 2025-02-05 at 1 23 37 PM" src="https://github.com/user-attachments/assets/65dbab18-84f5-4fa9-9de7-7c224d7bc0cd" />

I found a workaround for suppressing the console warnings we see all the time 

https://github.com/ant-design/ant-design/issues/48709#issuecomment-2460348481