### PR TITLE
Faith/mkt 687 final design feedback (All pages)

### DIFF
--- a/src/components/barchart/BarChart.tsx
+++ b/src/components/barchart/BarChart.tsx
@@ -81,10 +81,11 @@ const BarChart = ({
             ...exporting?.chartOptions?.title?.style,
           },
         },
-        series: series.map(() => ({
+        series: series.map((s) => ({
           type: 'column',
-          color: '#253761', // --j2-blue-9
+          color: s.color ? s.color : '#253761', // --j2-blue-9
         })),
+        legend: exporting?.chartOptions?.legend || { enabled: false },
       },
     },
     title: {

--- a/src/components/table/Table.module.css
+++ b/src/components/table/Table.module.css
@@ -37,3 +37,7 @@
 :global(.ant-spin-container.ant-spin-blur) th svg {
   visibility: hidden;
 }
+
+:global(.ant-table-thead) > tr > th {
+  white-space: nowrap;
+}


### PR DESCRIPTION
[MKT-687](https://j2health.atlassian.net/browse/MKT-687)

BarChart - allows for 2 bar colors and the associated legend to be included in the export if needed
Table - header content will no longer wrap to newlines which was causing the header height to be really long and not uniform 

Before
![chart (13)](https://github.com/user-attachments/assets/fa26d056-4189-4639-b49f-b877da806c3c)
Vs.
![chart (24)](https://github.com/user-attachments/assets/5d7d6980-0923-46fa-a05d-4cbb91df80fe)

[MKT-687]: https://j2health.atlassian.net/browse/MKT-687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ