### PR TITLE
Hide table header text when loading

### DIFF
--- a/src/components/table/Table.module.css
+++ b/src/components/table/Table.module.css
@@ -34,7 +34,8 @@
 }
 
 :global(.ant-spin-container.ant-spin-blur) th :global(.ant-table-column-title),
-:global(.ant-spin-container.ant-spin-blur) th svg {
+:global(.ant-spin-container.ant-spin-blur) th svg,
+:global(.ant-spin-container.ant-spin-blur) th span {
   visibility: hidden;
 }
 


### PR DESCRIPTION
<img width="1200" alt="Screenshot 2025-04-03 at 11 29 57 AM" src="https://github.com/user-attachments/assets/1f35dcbd-b4c2-4186-8179-98aca5ab19e0" />
