### PR TITLE
MKT-782 Hide overflow of filter form select

### DIFF
--- a/src/components/filterform/FilterInput.tsx
+++ b/src/components/filterform/FilterInput.tsx
@@ -5,6 +5,7 @@ import { Input, InputNumber, Select } from 'antd'
 import { FormFilter } from './types'
 import cx from 'classnames'
 import { SizeType } from 'antd/es/config-provider/SizeContext'
+
 type SelectValueInputConfig = {
   type: 'select'
   valueOptions: { label: string; value: string }[]
@@ -149,7 +150,7 @@ const ValueInput = ({
           mode="multiple"
           onBlur={onBlur}
           value={values}
-          className="w-full"
+          className="w-full truncate"
           size={size}
           optionFilterProp="label"
         />


### PR DESCRIPTION
[MKT-782](https://j2health.atlassian.net/browse/MKT-782)

TIL Tailwind truncate = `overflow: hidden; text-overflow: ellipsis; white-space: nowrap;` !

<img width="959" alt="Screenshot 2025-05-15 at 4 33 11 PM" src="https://github.com/user-attachments/assets/ab6db40f-5965-4665-aeb6-c67ef1d48b08" />


[MKT-782]: https://j2health.atlassian.net/browse/MKT-782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ