### PR TITLE
NAVY-822: Network selector looking very narrow in production

### DIFF
--- a/src/components/select/SummarizedSelect.module.css
+++ b/src/components/select/SummarizedSelect.module.css
@@ -61,6 +61,7 @@
 .headlinedSelect:global(.ant-select):global(.ant-select-single) {
   font-size: var(--j2-font-size-heading-2);
   height: 40px;
+  width: fit-content !important;
 }
 
 .headlinedSelect:global(.ant-select) :global(.ant-select-selector) {


### PR DESCRIPTION
[Linear](https://linear.app/j2health/issue/NAVY-822/network-selector-looking-very-narrow-in-production)

---

## Change Summary

Restore fit-content width for the headlined variant of SummarizedSelect, which was inadvertently removed in #207 causing text truncation.