### PR TITLE
fix(tailwind): annotate fontSize tuple so satisfies Config passes

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -153,7 +153,7 @@ export const tailwindPreset = {
         'j2-xs': [
           'var(--j2-font-size-xs)',
           { lineHeight: 'var(--j2-line-height-xs)' },
-        ],
+        ] as [string, { lineHeight: string }],
       },
       spacing: {
         j2: 'var(--j2-size)',


### PR DESCRIPTION
## Summary
- TypeScript was widening the `j2-xs` `fontSize` entry to `(string | {lineHeight})[]` instead of Tailwind's expected tuple shape `[string, {lineHeight: string}]`.
- `satisfies Config` at the default export was therefore failing in consuming apps.
- One-line tuple annotation restores correct inference.

## Impact
- Unblocks `npm run type-check` in `j2-health/j2` (was failing the branch's pre-commit hook for any frontend commit since DS `060c1c1` landed as the pointer in NAVY-796).
- No runtime change — pure type annotation.

## Test plan
- [x] `npm run type-check` in `j2-health/j2` repo passes with this submodule pointer applied.
- [x] DS `tailwind.config.ts` still prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)