### PR TITLE
fix(LegacyNavMenu): swap @ts-expect-error for @ts-ignore on J2Logo

### DIFF
--- a/src/components/legacyNavMenu/LegacyNavMenu.tsx
+++ b/src/components/legacyNavMenu/LegacyNavMenu.tsx
@@ -52,7 +52,7 @@ export const LegacyNavMenu: React.FC<LegacyNavMenuProps> = ({
       <div className={styles.logoSection}>
         <div className={styles.logoContainer}>
           <a href={logoUrl} className={styles.logoLink}>
-            {/* @ts-expect-error - SVG component props */}
+            {/* @ts-ignore - SVG component props vary across React typings */}
             <J2Logo className={styles.logo} />
           </a>
         </div>


### PR DESCRIPTION
## Why

Consumers building against this submodule with stricter `tsconfig`
settings (`noUnusedLocals`, `strict`, etc.) hit:

```
src/components/legacyNavMenu/LegacyNavMenu.tsx(55,14): error TS2578: Unused '@ts-expect-error' directive.
```

The directive only works when there's actually a suppressible error on
the next line. With current `@types/react` typings the
`<J2Logo className={...} />` invocation passes cleanly, so the
directive is unused and TS errors out.

## What

Swap `@ts-expect-error` → `@ts-ignore`. `@ts-ignore` is silent when
there's no error, so it keeps the suppression for any consumer whose
React types still flag the line while not breaking strict consumers.

## Context

I hit this while bootstrapping a stripped-down React mockup template
(`product-team-mockups/template-project`) that vendors design-system
as a submodule. Happy to revert if you'd rather solve it by tightening
the SVGr typings instead.