### PR TITLE
NAVY-1027: fix BarChart popover (outside + category key + z-index)

### DIFF
--- a/src/components/barchart/BarChart.tsx
+++ b/src/components/barchart/BarChart.tsx
@@ -179,6 +179,7 @@ const BarChart = ({
       backgroundColor: 'transparent',
       shadow: false,
       padding: 0,
+      style: { zIndex: 9999 },
       formatter: function (this) {
         return renderToString(
           <div className={styles.tooltip}>

--- a/src/components/barchart/BarChart.tsx
+++ b/src/components/barchart/BarChart.tsx
@@ -182,7 +182,7 @@ const BarChart = ({
       formatter: function (this) {
         return renderToString(
           <div className={styles.tooltip}>
-            {tooltip(this.x, this.y, this.series.name)}
+            {tooltip(this.key, this.y, this.series.name)}
           </div>
         )
       },

--- a/src/components/barchart/BarChart.tsx
+++ b/src/components/barchart/BarChart.tsx
@@ -175,6 +175,7 @@ const BarChart = ({
     })),
     tooltip: {
       useHTML: true,
+      outside: true,
       backgroundColor: 'transparent',
       shadow: false,
       padding: 0,


### PR DESCRIPTION
## Summary

Three small fixes to `BarChart`'s Highcharts tooltip so the hover popover renders correctly above page chrome in the NID Explore "Plans" tab.

1. **`tooltip.outside: true`** — portals the tooltip into `<body>` instead of rendering it inside the chart container.
2. **`this.key` instead of `this.x` in the formatter** — in Highcharts 12 with a categorical x-axis, `this.x` is the numeric index. Every callsite (`compare/.../Chart.tsx`, `explore/.../PlansChart.tsx`, `BarChart.stories.tsx`) treats the first formatter arg as the category *string* and looks values up by it, so we'd return `null` for the first bar (index 0 is falsy) and zeroed values for the rest. `this.key` is always the category string.
3. **`tooltip.style.zIndex: 9999`** — Highcharts gives `.highcharts-tooltip-container` a default z-index of `max(style.zIndex, 3)` ([`Tooltip.js:312`](https://github.com/highcharts/highcharts/blob/master/ts/Core/Tooltip.ts)). With `outside: true` the container is appended to `<body>`, but z-3 still loses to the `z-50` "View plans by..." header on the Explore Plans tab.

## Why

[NAVY-1027](https://linear.app/j2health/issue/NAVY-1027) — in the NID Explore "Plans" tab, hovering over the top bar shows the plan breadth popover painted **underneath** the "View plans by..." header.

> @Nick Brandecker said:
> > when I am looking at a marketability explore tab, the "View plans by...." is blocking the pop out when I hover over the top plan.

The header has to keep `z-50` — the chart is pulled up with `-mt-12` (BEY-363 / NID#933) so the chart SVG and carrier logos would otherwise paint over "View plans by..." in the overlap zone. The only viable fix is to push the tooltip's stacking above the header, which is what this PR does.

## Test plan

- [x] `npm test` — `barchart.test.tsx` snapshot unchanged (snapshot captures the initial chart, not the hover tooltip).
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint src/components/barchart` clean.
- [x] Manual: NID Explore → Plans → hover top bar → popover renders fully above the header with the right plan name and counts.

## Stacked with

`j2-health/network-intel-dashboard#1171` — submodule pin bump.

## History

Originally opened as #223 from a `j2-health-bot` fork; reopened from a same-repo branch so the `claude-review` workflow can fetch its OIDC token.