### PR TITLE
NAVY-821: add select-all / clear-all footer to multi-select Select

### DIFF
--- a/src/components/select/Select.stories.tsx
+++ b/src/components/select/Select.stories.tsx
@@ -101,6 +101,69 @@ export const Multiple: Story = {
   ),
 }
 
+// MultipleSelectAll demonstrates the "Select all" / "Clear all" footer that
+// renders on multi-select dropdowns. Footer hides while the user is filtering
+// via the inline search.
+
+const stateOptions = [
+  { label: 'Alabama', value: '01' },
+  { label: 'Alaska', value: '02' },
+  { label: 'Arizona', value: '04' },
+  { label: 'Arkansas', value: '05' },
+  { label: 'California', value: '06' },
+  { label: 'Colorado', value: '08' },
+  { label: 'Connecticut', value: '09' },
+  { label: 'Delaware', value: '10' },
+  { label: 'Florida', value: '12' },
+  { label: 'Georgia', value: '13' },
+  { label: 'Hawaii', value: '15' },
+  { label: 'Idaho', value: '16' },
+  { label: 'Illinois', value: '17' },
+  { label: 'Indiana', value: '18' },
+  { label: 'Iowa', value: '19' },
+  { label: 'Kansas', value: '20' },
+]
+
+export const MultipleSelectAllEmpty: Story = {
+  args: {
+    name: 'states',
+    size: 'middle',
+    mode: 'multiple',
+    placeholder: 'Select states',
+    showSearch: true,
+    optionFilterProp: 'label',
+    allowClear: true,
+    options: stateOptions,
+  },
+  render: (args) => (
+    <Formik initialValues={{ states: [] }} onSubmit={() => {}}>
+      <Form>
+        <Select {...args} className="w-96" />
+      </Form>
+    </Formik>
+  ),
+}
+
+export const MultipleSelectAllPartial: Story = {
+  args: {
+    name: 'states',
+    size: 'middle',
+    mode: 'multiple',
+    placeholder: 'Select states',
+    showSearch: true,
+    optionFilterProp: 'label',
+    allowClear: true,
+    options: stateOptions,
+  },
+  render: (args) => (
+    <Formik initialValues={{ states: ['06', '12'] }} onSubmit={() => {}}>
+      <Form>
+        <Select {...args} className="w-96" />
+      </Form>
+    </Formik>
+  ),
+}
+
 export const Loading: Story = {
   args: {
     ...Basic.args,

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -54,61 +54,57 @@ export const Select = (props: SelectProps) => {
 
   const handleToggleAll = () => {
     if (currentValue.length === 0) {
-      const allValues = flattenOptions(
+      const flat = flattenOptions(
         props.options as (DefaultOptionType | GroupOption)[] | undefined
       )
-        .map((opt) => opt.value)
-        .filter((v): v is string | number => v !== undefined && v !== null)
+      const allOptions = flat.filter(
+        (opt) => opt.value !== undefined && opt.value !== null
+      )
+      const allValues = allOptions.map((opt) => opt.value as string | number)
       void helpers.setValue(allValues)
+      props.onChange?.(allValues, allOptions)
     } else {
       void helpers.setValue([])
+      props.onChange?.([], [])
     }
   }
 
-  const dropdownRender = React.useCallback(
-    (menu: React.ReactElement): React.ReactElement => {
-      if (props.loading) {
-        return (
-          <div className="flex items-center justify-between px-3 py-1">
-            <span>Loading...</span>
-            <Spin indicator={<LoadingOutlined spin />} size="small" />
-          </div>
-        )
-      }
-
-      if (!props.options || (props.options && props.options.length === 0)) {
-        return <div className="px-3 py-1">No options</div>
-      }
-
-      if (!showSelectAllFooter) return menu
-
-      const label = currentValue.length === 0 ? 'Select all' : 'Clear all'
-
+  const dropdownRender = (menu: React.ReactElement): React.ReactElement => {
+    if (props.loading) {
       return (
-        <>
-          {menu}
-          <div className="mt-1 pt-1 border-t border-j2-border-secondary">
-            <div
-              role="button"
-              aria-label={label}
-              title={label}
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={handleToggleAll}
-              className="text-center font-semibold text-sm py-1.5 rounded cursor-pointer text-j2-primary hover:bg-j2-primary-bg-hover"
-            >
-              {label}
-            </div>
-          </div>
-        </>
+        <div className="flex items-center justify-between px-3 py-1">
+          <span>Loading...</span>
+          <Spin indicator={<LoadingOutlined spin />} size="small" />
+        </div>
       )
-    },
-    [
-      props.loading,
-      props.options?.length,
-      showSelectAllFooter,
-      currentValue.length,
-    ]
-  )
+    }
+
+    if (!props.options || (props.options && props.options.length === 0)) {
+      return <div className="px-3 py-1">No options</div>
+    }
+
+    if (!showSelectAllFooter) return menu
+
+    const label = currentValue.length === 0 ? 'Select all' : 'Clear all'
+
+    return (
+      <>
+        {menu}
+        <div className="mt-1 pt-1 border-t border-j2-border-secondary">
+          <button
+            type="button"
+            aria-label={label}
+            title={label}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={handleToggleAll}
+            className="w-full text-center font-semibold text-sm py-1.5 rounded cursor-pointer text-j2-primary hover:bg-j2-primary-bg-hover bg-transparent border-0"
+          >
+            {label}
+          </button>
+        </div>
+      </>
+    )
+  }
 
   return (
     <AntDSelect

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -43,7 +43,11 @@ export const Select = (props: SelectProps) => {
   const hasOptions = (props.options?.length ?? 0) > 0
   const currentValue: unknown[] = Array.isArray(field.value) ? field.value : []
   const showSelectAllFooter =
-    isMultiple && !props.loading && hasOptions && !isSearching
+    isMultiple &&
+    !props.loading &&
+    !props.disabled &&
+    hasOptions &&
+    !isSearching
 
   const handleSearch = (value: string) => {
     setIsSearching(value.length > 0)
@@ -53,6 +57,8 @@ export const Select = (props: SelectProps) => {
   }
 
   const handleToggleAll = () => {
+    if (props.disabled) return
+
     if (currentValue.length === 0) {
       const flat = flattenOptions(
         props.options as (DefaultOptionType | GroupOption)[] | undefined
@@ -60,9 +66,14 @@ export const Select = (props: SelectProps) => {
       const allOptions = flat.filter(
         (opt) => opt.value !== undefined && opt.value !== null
       )
-      const allValues = allOptions.map((opt) => opt.value as string | number)
-      void helpers.setValue(allValues)
-      props.onChange?.(allValues, allOptions)
+      // antd's labelInValue mode expects values shaped as { value, label }
+      // rather than raw scalars; mirror that contract so the field state
+      // and downstream onChange payload match what consumers expect.
+      const payload = props.labelInValue
+        ? allOptions.map((opt) => ({ value: opt.value, label: opt.label }))
+        : allOptions.map((opt) => opt.value as string | number)
+      void helpers.setValue(payload)
+      props.onChange?.(payload, allOptions)
     } else {
       void helpers.setValue([])
       props.onChange?.([], [])

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -64,7 +64,7 @@ export const Select = (props: SelectProps) => {
         props.options as (DefaultOptionType | GroupOption)[] | undefined
       )
       const allOptions = flat.filter(
-        (opt) => opt.value !== undefined && opt.value !== null
+        (opt) => opt.value !== undefined && opt.value !== null && !opt.disabled
       )
       // antd's labelInValue mode expects values shaped as { value, label }
       // rather than raw scalars; mirror that contract so the field state

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -2,24 +2,66 @@ import * as React from 'react'
 import { Select as AntDSelect } from 'formik-antd'
 import { Spin } from 'antd'
 import { LoadingOutlined } from '@ant-design/icons'
-import type { SelectProps as AntDSelectProps } from 'antd'
+import type {
+  SelectProps as AntDSelectProps,
+  DefaultOptionType,
+} from 'antd/es/select'
 import {
   CaretDownIcon,
   MagnifyingGlassIcon,
   XCircleIcon,
 } from '@phosphor-icons/react'
 import { useState } from 'react'
+import { useField } from 'formik'
 
 type SelectProps = Expand<AntDSelectProps> & {
   name: string
 }
 
+type GroupOption = { label?: React.ReactNode; options: DefaultOptionType[] }
+
+const isGroupOption = (
+  opt: DefaultOptionType | GroupOption
+): opt is GroupOption =>
+  'options' in opt && Array.isArray((opt as GroupOption).options)
+
+const flattenOptions = (
+  opts: (DefaultOptionType | GroupOption)[] | undefined
+): DefaultOptionType[] => {
+  if (!opts) return []
+  return opts.flatMap((o) =>
+    isGroupOption(o) ? flattenOptions(o.options) : [o]
+  )
+}
+
 export const Select = (props: SelectProps) => {
   const [isFocused, setIsFocused] = useState(false)
+  const [isSearching, setIsSearching] = useState(false)
+  const [field, , helpers] = useField(props.name)
+
+  const isMultiple = props.mode === 'multiple'
+  const hasOptions = (props.options?.length ?? 0) > 0
+  const currentValue: unknown[] = Array.isArray(field.value) ? field.value : []
+  const showSelectAllFooter =
+    isMultiple && !props.loading && hasOptions && !isSearching
 
   const handleSearch = (value: string) => {
+    setIsSearching(value.length > 0)
     if (props.onSearch) {
       props.onSearch(value)
+    }
+  }
+
+  const handleToggleAll = () => {
+    if (currentValue.length === 0) {
+      const allValues = flattenOptions(
+        props.options as (DefaultOptionType | GroupOption)[] | undefined
+      )
+        .map((opt) => opt.value)
+        .filter((v): v is string | number => v !== undefined && v !== null)
+      void helpers.setValue(allValues)
+    } else {
+      void helpers.setValue([])
     }
   }
 
@@ -38,9 +80,34 @@ export const Select = (props: SelectProps) => {
         return <div className="px-3 py-1">No options</div>
       }
 
-      return menu
+      if (!showSelectAllFooter) return menu
+
+      const label = currentValue.length === 0 ? 'Select all' : 'Clear all'
+
+      return (
+        <>
+          {menu}
+          <div className="mt-1 pt-1 border-t border-j2-border-secondary">
+            <div
+              role="button"
+              aria-label={label}
+              title={label}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={handleToggleAll}
+              className="text-center font-semibold text-sm py-1.5 rounded cursor-pointer text-j2-primary hover:bg-j2-primary-bg-hover"
+            >
+              {label}
+            </div>
+          </div>
+        </>
+      )
     },
-    [props.loading, props.options?.length]
+    [
+      props.loading,
+      props.options?.length,
+      showSelectAllFooter,
+      currentValue.length,
+    ]
   )
 
   return (
@@ -65,12 +132,13 @@ export const Select = (props: SelectProps) => {
         props.allowClear ? { clearIcon: <XCircleIcon size={14} /> } : false
       }
       showSearch={props.showSearch}
-      onSearch={props.onSearch ? handleSearch : undefined}
+      onSearch={handleSearch}
       onFocus={() => {
         setIsFocused(true)
       }}
       onBlur={() => {
         setIsFocused(false)
+        setIsSearching(false)
       }}
       size={props.size || 'large'}
     />

--- a/src/components/select/__tests__/select.test.tsx
+++ b/src/components/select/__tests__/select.test.tsx
@@ -1,6 +1,7 @@
 import { vi } from 'vitest'
-import { render, fireEvent } from '@testing-library/react'
-import { Formik } from 'formik'
+import { render, fireEvent, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Formik, useFormikContext } from 'formik'
 import { Form } from 'formik-antd'
 import { Select } from '../Select'
 
@@ -11,6 +12,34 @@ const renderWithForm = (selectElement: JSX.Element) => {
     </Formik>
   )
 }
+
+// Exposes the current Formik values via a data-testid so tests can assert on
+// state changes the Select pushes to the form (e.g. select-all / clear-all).
+const FormStateProbe = () => {
+  const { values } = useFormikContext<Record<string, unknown>>()
+  return <div data-testid="form-state">{JSON.stringify(values)}</div>
+}
+
+const renderMultipleWithForm = (
+  selectElement: JSX.Element,
+  initialValue: string[] = []
+) => {
+  return render(
+    <Formik initialValues={{ test: initialValue }} onSubmit={() => {}}>
+      <Form>
+        {selectElement}
+        <FormStateProbe />
+      </Form>
+    </Formik>
+  )
+}
+
+const planOptions = [
+  { label: 'Bronze Plan', value: 'bronze' },
+  { label: 'Silver Plan', value: 'silver' },
+  { label: 'Gold Plan', value: 'gold' },
+  { label: 'Platinum Plan', value: 'platinum' },
+]
 
 describe('Select', () => {
   it('should render correctly', () => {
@@ -115,5 +144,180 @@ describe('Select', () => {
     fireEvent.mouseOver(container.firstChild as Element)
     expect(container.querySelector('[data-testid="clear-icon"]')).toBeFalsy()
     expect(container).toMatchSnapshot()
+  })
+
+  describe('Multiple mode select-all / clear-all footer', () => {
+    it('renders "Select all" footer when value is empty', async () => {
+      const user = userEvent.setup()
+      renderMultipleWithForm(
+        <Select name="test" mode="multiple" options={planOptions} />
+      )
+
+      await user.click(screen.getByRole('combobox'))
+
+      expect(await screen.findByText('Select all')).toBeInTheDocument()
+      expect(screen.queryByText('Clear all')).not.toBeInTheDocument()
+    })
+
+    it('renders "Clear all" footer when value has items', async () => {
+      const user = userEvent.setup()
+      renderMultipleWithForm(
+        <Select name="test" mode="multiple" options={planOptions} />,
+        ['bronze', 'silver']
+      )
+
+      await user.click(screen.getByRole('combobox'))
+
+      expect(await screen.findByText('Clear all')).toBeInTheDocument()
+      expect(screen.queryByText('Select all')).not.toBeInTheDocument()
+    })
+
+    it('selects every option when "Select all" is clicked', async () => {
+      const user = userEvent.setup()
+      renderMultipleWithForm(
+        <Select name="test" mode="multiple" options={planOptions} />
+      )
+
+      await user.click(screen.getByRole('combobox'))
+      await user.click(await screen.findByText('Select all'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-state')).toHaveTextContent(
+          JSON.stringify({ test: ['bronze', 'silver', 'gold', 'platinum'] })
+        )
+      })
+    })
+
+    it('empties value when "Clear all" is clicked', async () => {
+      const user = userEvent.setup()
+      renderMultipleWithForm(
+        <Select name="test" mode="multiple" options={planOptions} />,
+        ['bronze', 'silver']
+      )
+
+      await user.click(screen.getByRole('combobox'))
+      await user.click(await screen.findByText('Clear all'))
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-state')).toHaveTextContent(
+          JSON.stringify({ test: [] })
+        )
+      })
+    })
+
+    it('flips label from "Select all" to "Clear all" after selecting all', async () => {
+      const user = userEvent.setup()
+      renderMultipleWithForm(
+        <Select name="test" mode="multiple" options={planOptions} />
+      )
+
+      await user.click(screen.getByRole('combobox'))
+      await user.click(await screen.findByText('Select all'))
+
+      expect(await screen.findByText('Clear all')).toBeInTheDocument()
+      expect(screen.queryByText('Select all')).not.toBeInTheDocument()
+    })
+
+    it('hides footer while user is searching', async () => {
+      const user = userEvent.setup()
+      renderMultipleWithForm(
+        <Select
+          name="test"
+          mode="multiple"
+          showSearch
+          optionFilterProp="label"
+          options={planOptions}
+        />
+      )
+
+      const combobox = screen.getByRole('combobox')
+      await user.click(combobox)
+      expect(await screen.findByText('Select all')).toBeInTheDocument()
+
+      await user.type(combobox, 'bro')
+
+      await waitFor(() => {
+        expect(screen.queryByText('Select all')).not.toBeInTheDocument()
+      })
+      expect(screen.queryByText('Clear all')).not.toBeInTheDocument()
+    })
+
+    it('restores footer when search input is cleared', async () => {
+      const user = userEvent.setup()
+      renderMultipleWithForm(
+        <Select
+          name="test"
+          mode="multiple"
+          showSearch
+          optionFilterProp="label"
+          options={planOptions}
+        />
+      )
+
+      const combobox = screen.getByRole('combobox')
+      await user.click(combobox)
+      await user.type(combobox, 'bro')
+      await waitFor(() => {
+        expect(screen.queryByText('Select all')).not.toBeInTheDocument()
+      })
+
+      await user.clear(combobox)
+
+      expect(await screen.findByText('Select all')).toBeInTheDocument()
+    })
+
+    it('does not render footer in single-select mode', async () => {
+      const user = userEvent.setup()
+      renderWithForm(<Select name="test" options={planOptions} />)
+
+      await user.click(screen.getByRole('combobox'))
+      // The Bronze Plan option should be visible to confirm dropdown is open.
+      expect(await screen.findByText('Bronze Plan')).toBeInTheDocument()
+      expect(screen.queryByText('Select all')).not.toBeInTheDocument()
+      expect(screen.queryByText('Clear all')).not.toBeInTheDocument()
+    })
+
+    it('does not render footer when loading', async () => {
+      const user = userEvent.setup()
+      renderMultipleWithForm(
+        <Select name="test" mode="multiple" loading options={planOptions} />
+      )
+
+      await user.click(screen.getByRole('combobox'))
+      expect(await screen.findByText('Loading...')).toBeInTheDocument()
+      expect(screen.queryByText('Select all')).not.toBeInTheDocument()
+    })
+
+    it('does not render footer when options list is empty', async () => {
+      const user = userEvent.setup()
+      renderMultipleWithForm(
+        <Select name="test" mode="multiple" options={[]} />
+      )
+
+      await user.click(screen.getByRole('combobox'))
+      expect(await screen.findByText('No options')).toBeInTheDocument()
+      expect(screen.queryByText('Select all')).not.toBeInTheDocument()
+    })
+
+    it('forwards consumer onSearch callback while tracking search internally', async () => {
+      const user = userEvent.setup()
+      const handleSearch = vi.fn()
+      renderMultipleWithForm(
+        <Select
+          name="test"
+          mode="multiple"
+          showSearch
+          optionFilterProp="label"
+          onSearch={handleSearch}
+          options={planOptions}
+        />
+      )
+
+      const combobox = screen.getByRole('combobox')
+      await user.click(combobox)
+      await user.type(combobox, 'bro')
+
+      expect(handleSearch).toHaveBeenCalledWith('bro')
+    })
   })
 })

--- a/src/components/select/__tests__/select.test.tsx
+++ b/src/components/select/__tests__/select.test.tsx
@@ -381,6 +381,51 @@ describe('Select', () => {
       expect(option).toEqual(planOptions)
     })
 
+    it('selects across grouped options and skips disabled entries on "Select all"', async () => {
+      const user = userEvent.setup()
+      const handleChange = vi.fn()
+      const groupedOptions = [
+        {
+          label: 'Metals',
+          options: [
+            { label: 'Bronze Plan', value: 'bronze' },
+            { label: 'Silver Plan', value: 'silver', disabled: true },
+            { label: 'Gold Plan', value: 'gold' },
+          ],
+        },
+        {
+          label: 'Premium',
+          options: [{ label: 'Platinum Plan', value: 'platinum' }],
+        },
+      ]
+
+      renderMultipleWithForm(
+        <Select
+          name="test"
+          mode="multiple"
+          options={groupedOptions}
+          onChange={handleChange}
+        />
+      )
+
+      await user.click(screen.getByRole('combobox'))
+      await user.click(await screen.findByText('Select all'))
+
+      const expectedValues = ['bronze', 'gold', 'platinum']
+      const expectedOptions = [
+        { label: 'Bronze Plan', value: 'bronze' },
+        { label: 'Gold Plan', value: 'gold' },
+        { label: 'Platinum Plan', value: 'platinum' },
+      ]
+
+      await waitFor(() => {
+        expect(screen.getByTestId('form-state')).toHaveTextContent(
+          JSON.stringify({ test: expectedValues })
+        )
+      })
+      expect(handleChange).toHaveBeenCalledWith(expectedValues, expectedOptions)
+    })
+
     it('forwards consumer onSearch callback while tracking search internally', async () => {
       const user = userEvent.setup()
       const handleSearch = vi.fn()

--- a/src/components/select/__tests__/select.test.tsx
+++ b/src/components/select/__tests__/select.test.tsx
@@ -299,6 +299,46 @@ describe('Select', () => {
       expect(screen.queryByText('Select all')).not.toBeInTheDocument()
     })
 
+    it('forwards consumer onChange when "Select all" is clicked', async () => {
+      const user = userEvent.setup()
+      const handleChange = vi.fn()
+      renderMultipleWithForm(
+        <Select
+          name="test"
+          mode="multiple"
+          options={planOptions}
+          onChange={handleChange}
+        />
+      )
+
+      await user.click(screen.getByRole('combobox'))
+      await user.click(await screen.findByText('Select all'))
+
+      expect(handleChange).toHaveBeenCalledTimes(1)
+      const [value, option] = handleChange.mock.calls[0]
+      expect(value).toEqual(['bronze', 'silver', 'gold', 'platinum'])
+      expect(option).toEqual(planOptions)
+    })
+
+    it('forwards consumer onChange when "Clear all" is clicked', async () => {
+      const user = userEvent.setup()
+      const handleChange = vi.fn()
+      renderMultipleWithForm(
+        <Select
+          name="test"
+          mode="multiple"
+          options={planOptions}
+          onChange={handleChange}
+        />,
+        ['bronze', 'silver']
+      )
+
+      await user.click(screen.getByRole('combobox'))
+      await user.click(await screen.findByText('Clear all'))
+
+      expect(handleChange).toHaveBeenCalledWith([], [])
+    })
+
     it('forwards consumer onSearch callback while tracking search internally', async () => {
       const user = userEvent.setup()
       const handleSearch = vi.fn()

--- a/src/components/select/__tests__/select.test.tsx
+++ b/src/components/select/__tests__/select.test.tsx
@@ -339,6 +339,48 @@ describe('Select', () => {
       expect(handleChange).toHaveBeenCalledWith([], [])
     })
 
+    it('does not render footer when the Select is disabled', async () => {
+      const user = userEvent.setup()
+      renderMultipleWithForm(
+        <Select name="test" mode="multiple" disabled options={planOptions} />
+      )
+
+      await user.click(screen.getByRole('combobox'))
+      // antd already prevents the popup from opening when disabled; the
+      // !props.disabled gate in showSelectAllFooter is a defense-in-depth
+      // belt-and-suspenders for cases where the dropdown might be forced
+      // open programmatically.
+      expect(screen.queryByText('Select all')).not.toBeInTheDocument()
+      expect(screen.queryByText('Clear all')).not.toBeInTheDocument()
+    })
+
+    it('pushes labelInValue-shaped payload when labelInValue is set', async () => {
+      const user = userEvent.setup()
+      const handleChange = vi.fn()
+      renderMultipleWithForm(
+        <Select
+          name="test"
+          mode="multiple"
+          labelInValue
+          options={planOptions}
+          onChange={handleChange}
+        />
+      )
+
+      await user.click(screen.getByRole('combobox'))
+      await user.click(await screen.findByText('Select all'))
+
+      expect(handleChange).toHaveBeenCalledTimes(1)
+      const [value, option] = handleChange.mock.calls[0]
+      expect(value).toEqual([
+        { value: 'bronze', label: 'Bronze Plan' },
+        { value: 'silver', label: 'Silver Plan' },
+        { value: 'gold', label: 'Gold Plan' },
+        { value: 'platinum', label: 'Platinum Plan' },
+      ])
+      expect(option).toEqual(planOptions)
+    })
+
     it('forwards consumer onSearch callback while tracking search internally', async () => {
       const user = userEvent.setup()
       const handleSearch = vi.fn()


### PR DESCRIPTION
## Summary
- Adds a "Select all" / "Clear all" toggle to the popup footer of the design-system `Select` when used in `mode="multiple"`.
- Label flips on the current value: empty → "Select all", non-empty → "Clear all". Clicking "Select all" sets the field to every option value; "Clear all" empties it.
- Footer is suppressed while the user is filtering via the inline search, while `loading`, and when the option list is empty.
- New Storybook stories `MultipleSelectAllEmpty` and `MultipleSelectAllPartial` cover the two starting states.

## Why
[NAVY-821](https://linear.app/j2health/issue/NAVY-821/support-easy-selection-of-all-states-when-defining-a-multi-state) — the multi-state selector in the network creation form needs a quick way to select all states. The only j2 consumer of `Select` with `mode="multiple"` is `ServiceAreaSelector` (audited), so this change exists for that consumer but lives in the design system so future multi-selects get the affordance for free.

## How
- `Select.tsx`: reads/writes the Formik field via `useField(name)`, tracks an `isSearching` boolean fed by `onSearch`, and appends the footer in the existing `dropdownRender`. Footer toggles between "Select all" → `onChange(allOptionValues)` and "Clear all" → `onChange([])`. Grouped options are flattened.
- `Select.stories.tsx`: two new stories on a 16-state list.
- `select.test.tsx`: 11 new tests covering empty / partial states, the two-click cycle, search-hides-footer, search-clears-restores-footer, single-mode/loading/empty short-circuits, and consumer `onSearch` forwarding.

## Test plan
- [ ] `npm start` → Storybook → `Components / Select / Multiple Select All Empty`. Open dropdown, confirm "Select all", click → all 16 selected and label flips to "Clear all".
- [ ] `Multiple Select All Partial` → opens with "Clear all" (2 preselected) → click → empty, label flips to "Select all".
- [ ] Either story: type `ca` in the search → footer disappears. Clear the search → footer returns.
- [ ] Verify existing multi-Select usage in j2 (`ServiceAreaSelector`) still renders correctly after this lands.