### PR TITLE
NAVY-821: add opt-in lazyChildren prop to CheckboxTree

### DIFF
--- a/src/components/checkboxTree/Checkbox.stories.tsx
+++ b/src/components/checkboxTree/Checkbox.stories.tsx
@@ -11,6 +11,7 @@ const meta: Meta<typeof CheckboxTree> = {
   argTypes: {
     disabled: { control: 'boolean' },
     defaultExpandAll: { control: 'boolean' },
+    lazyChildren: { control: 'boolean' },
   },
 }
 
@@ -87,5 +88,23 @@ export const PartiallyExpanded: Story = {
   args: {
     treeData: simpleTreeData,
     defaultExpandedKeys: ['1'],
+  },
+}
+
+const largeTreeData = Array.from({ length: 6 }, (_, stateIndex) => ({
+  key: `state-${stateIndex}`,
+  title: `State ${stateIndex + 1} (40 counties)`,
+  children: Array.from({ length: 40 }, (_, countyIndex) => ({
+    key: `county-${stateIndex}-${countyIndex}`,
+    title: `County ${countyIndex + 1}`,
+  })),
+}))
+
+export const LazyChildren: Story = {
+  args: {
+    treeData: largeTreeData,
+    lazyChildren: true,
+    defaultExpandAll: false,
+    defaultCheckedKeys: ['county-0-0', 'county-0-1', 'county-0-2'],
   },
 }

--- a/src/components/checkboxTree/CheckboxTree.tsx
+++ b/src/components/checkboxTree/CheckboxTree.tsx
@@ -175,7 +175,7 @@ export const CheckboxTree = ({
         })
       }
     },
-    [controlledCheckedKeys, onCheck, treeData]
+    [controlledCheckedKeys, onCheck, treeData, leafNodeValues]
   )
 
   return (

--- a/src/components/checkboxTree/CheckboxTree.tsx
+++ b/src/components/checkboxTree/CheckboxTree.tsx
@@ -34,6 +34,7 @@ export type CheckboxTreeProps = {
   onExpand?: (expandedKeys: (string | number)[]) => void
   className?: string
   style?: React.CSSProperties
+  lazyChildren?: boolean
 }
 
 export const CheckboxTree = ({
@@ -48,6 +49,7 @@ export const CheckboxTree = ({
   onExpand,
   className,
   style,
+  lazyChildren = false,
 }: CheckboxTreeProps) => {
   const allLeafKeys = useMemo(() => getAllLeafKeys(treeData), [treeData])
   const leafKeySet = useMemo(() => new Set(allLeafKeys), [allLeafKeys])
@@ -188,6 +190,7 @@ export const CheckboxTree = ({
           disabled={disabled}
           expandedKeys={expandedKeysSet}
           onToggleExpand={handleToggleExpand}
+          lazyChildren={lazyChildren}
         />
       ))}
     </div>

--- a/src/components/checkboxTree/CheckboxTree.tsx
+++ b/src/components/checkboxTree/CheckboxTree.tsx
@@ -1,11 +1,6 @@
 import React, { useState, useCallback, useEffect, useMemo } from 'react'
 import { TreeNode } from './TreeNode'
-import {
-  getLeafKeys,
-  getAllLeafKeys,
-  getAllParentKeys,
-  isNodeChecked,
-} from './utils'
+import { getLeafKeys, getAllLeafKeys, getAllParentKeys } from './utils'
 
 export type CheckboxTreeDataNode = {
   key: string | number
@@ -150,22 +145,27 @@ export const CheckboxTree = ({
         // Get all nodes that appear checked (including parents)
         const allCheckedNodes: CheckboxTreeDataNode[] = []
 
-        const traverse = (nodes: CheckboxTreeDataNode[]) => {
-          nodes.forEach((node) => {
-            if (isNodeChecked(node, newLeafNodeValues)) {
-              allCheckedNodes.push(node)
-
-              // If it's a leaf node, add to checkedLeafNodes
-              if (!node.children || node.children.length === 0) {
-                checkedLeafNodes[node.key] = node
+        const collectChecked = (current: CheckboxTreeDataNode): boolean => {
+          let isChecked: boolean
+          if (!current.children || current.children.length === 0) {
+            isChecked = newLeafNodeValues[current.key] === true
+            if (isChecked) {
+              checkedLeafNodes[current.key] = current
+            }
+          } else {
+            isChecked = true
+            for (const child of current.children) {
+              if (!collectChecked(child)) {
+                isChecked = false
               }
             }
-            if (node.children) {
-              traverse(node.children)
-            }
-          })
+          }
+          if (isChecked) {
+            allCheckedNodes.push(current)
+          }
+          return isChecked
         }
-        traverse(treeData)
+        treeData.forEach(collectChecked)
 
         onCheck(newLeafNodeValues, {
           checked,

--- a/src/components/checkboxTree/TreeNode.tsx
+++ b/src/components/checkboxTree/TreeNode.tsx
@@ -1,7 +1,7 @@
 import { CaretDownIcon } from '@phosphor-icons/react'
 import { Checkbox } from '../checkbox'
 import { CheckboxTreeDataNode } from './CheckboxTree'
-import { isNodeChecked, isNodeIndeterminate } from './utils'
+import { getNodeCheckState } from './utils'
 
 type TreeNodeProps = {
   node: CheckboxTreeDataNode
@@ -28,9 +28,11 @@ export const TreeNode = ({
   onToggleExpand,
   lazyChildren,
 }: TreeNodeProps) => {
-  const isChecked = isNodeChecked(node, leafNodeValues)
-  const isIndeterminate =
-    lazyChildren && !isChecked && isNodeIndeterminate(node, leafNodeValues)
+  const { checked: isChecked, indeterminate } = getNodeCheckState(
+    node,
+    leafNodeValues
+  )
+  const isIndeterminate = lazyChildren && indeterminate
   const isDisabled = disabled || node.disabled
   const hasChildren = node.children && node.children.length > 0
   const isExpanded = expandedKeys.has(node.key)

--- a/src/components/checkboxTree/TreeNode.tsx
+++ b/src/components/checkboxTree/TreeNode.tsx
@@ -30,7 +30,7 @@ export const TreeNode = ({
 }: TreeNodeProps) => {
   const isChecked = isNodeChecked(node, leafNodeValues)
   const isIndeterminate =
-    lazyChildren && isNodeIndeterminate(node, leafNodeValues)
+    lazyChildren && !isChecked && isNodeIndeterminate(node, leafNodeValues)
   const isDisabled = disabled || node.disabled
   const hasChildren = node.children && node.children.length > 0
   const isExpanded = expandedKeys.has(node.key)

--- a/src/components/checkboxTree/TreeNode.tsx
+++ b/src/components/checkboxTree/TreeNode.tsx
@@ -1,7 +1,7 @@
 import { CaretDownIcon } from '@phosphor-icons/react'
 import { Checkbox } from '../checkbox'
 import { CheckboxTreeDataNode } from './CheckboxTree'
-import { isNodeChecked } from './utils'
+import { isNodeChecked, isNodeIndeterminate } from './utils'
 
 type TreeNodeProps = {
   node: CheckboxTreeDataNode
@@ -15,6 +15,7 @@ type TreeNodeProps = {
   disabled: boolean
   expandedKeys: Set<string | number>
   onToggleExpand: (key: string | number) => void
+  lazyChildren: boolean
 }
 
 export const TreeNode = ({
@@ -25,8 +26,11 @@ export const TreeNode = ({
   disabled,
   expandedKeys,
   onToggleExpand,
+  lazyChildren,
 }: TreeNodeProps) => {
   const isChecked = isNodeChecked(node, leafNodeValues)
+  const isIndeterminate =
+    lazyChildren && isNodeIndeterminate(node, leafNodeValues)
   const isDisabled = disabled || node.disabled
   const hasChildren = node.children && node.children.length > 0
   const isExpanded = expandedKeys.has(node.key)
@@ -39,6 +43,7 @@ export const TreeNode = ({
       >
         <Checkbox
           checked={isChecked}
+          indeterminate={isIndeterminate}
           disabled={isDisabled}
           onChange={(e) => onCheck(node.key, e.target.checked, node)}
         >
@@ -72,18 +77,20 @@ export const TreeNode = ({
           }}
         >
           <div style={{ overflow: 'hidden' }}>
-            {node.children!.map((childNode) => (
-              <TreeNode
-                key={childNode.key}
-                node={childNode}
-                level={level + 1}
-                leafNodeValues={leafNodeValues}
-                onCheck={onCheck}
-                disabled={disabled}
-                expandedKeys={expandedKeys}
-                onToggleExpand={onToggleExpand}
-              />
-            ))}
+            {(!lazyChildren || isExpanded) &&
+              node.children!.map((childNode) => (
+                <TreeNode
+                  key={childNode.key}
+                  node={childNode}
+                  level={level + 1}
+                  leafNodeValues={leafNodeValues}
+                  onCheck={onCheck}
+                  disabled={disabled}
+                  expandedKeys={expandedKeys}
+                  onToggleExpand={onToggleExpand}
+                  lazyChildren={lazyChildren}
+                />
+              ))}
           </div>
         </div>
       )}

--- a/src/components/checkboxTree/__tests__/checkboxTree.test.tsx
+++ b/src/components/checkboxTree/__tests__/checkboxTree.test.tsx
@@ -337,6 +337,18 @@ describe('CheckboxTree', () => {
       expect(projectA.checked).toBe(false)
     })
 
+    it('should preserve prior checks across consecutive clicks in uncontrolled mode', () => {
+      const onCheck = vi.fn()
+      render(<CheckboxTree treeData={simpleTreeData} onCheck={onCheck} />)
+
+      fireEvent.click(screen.getByLabelText('Project A'))
+      fireEvent.click(screen.getByLabelText('Images'))
+
+      const [values] = onCheck.mock.calls[onCheck.mock.calls.length - 1]
+      expect(values['0-0-0']).toBe(true)
+      expect(values['1-0']).toBe(true)
+    })
+
     it('should render nothing for empty treeData', () => {
       const { container } = render(<CheckboxTree treeData={[]} />)
       expect(container.firstChild).toBeEmptyDOMElement()

--- a/src/components/checkboxTree/__tests__/checkboxTree.test.tsx
+++ b/src/components/checkboxTree/__tests__/checkboxTree.test.tsx
@@ -360,7 +360,7 @@ describe('CheckboxTree', () => {
       expect(screen.queryByText('Images')).toBeNull()
     })
 
-    it('should mount a node’s children when it is expanded', () => {
+    it('should mount children when a node is expanded', () => {
       render(
         <CheckboxTree
           treeData={simpleTreeData}

--- a/src/components/checkboxTree/__tests__/checkboxTree.test.tsx
+++ b/src/components/checkboxTree/__tests__/checkboxTree.test.tsx
@@ -342,4 +342,74 @@ describe('CheckboxTree', () => {
       expect(container.firstChild).toBeEmptyDOMElement()
     })
   })
+
+  describe('lazyChildren', () => {
+    it('should not mount children of a collapsed node when lazyChildren is set', () => {
+      render(
+        <CheckboxTree
+          treeData={simpleTreeData}
+          defaultExpandAll={false}
+          lazyChildren
+        />
+      )
+
+      expect(screen.getByText('Documents')).toBeTruthy()
+      expect(screen.getByText('Media')).toBeTruthy()
+      expect(screen.queryByText('Projects')).toBeNull()
+      expect(screen.queryByText('Project A')).toBeNull()
+      expect(screen.queryByText('Images')).toBeNull()
+    })
+
+    it('should mount a node’s children when it is expanded', () => {
+      render(
+        <CheckboxTree
+          treeData={simpleTreeData}
+          defaultExpandAll={false}
+          lazyChildren
+        />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /Expand Documents/ }))
+
+      // Direct children appear...
+      expect(screen.getByText('Projects')).toBeTruthy()
+      expect(screen.getByText('Reports')).toBeTruthy()
+      // ...but their still-collapsed grandchildren do not.
+      expect(screen.queryByText('Project A')).toBeNull()
+    })
+
+    it('should keep collapsed children mounted by default (no lazyChildren)', () => {
+      render(
+        <CheckboxTree treeData={simpleTreeData} defaultExpandAll={false} />
+      )
+
+      // Default behavior is unchanged: collapsed children stay in the DOM.
+      expect(screen.getByText('Projects')).toBeTruthy()
+      expect(screen.getByText('Project A')).toBeTruthy()
+    })
+
+    it('should show an indeterminate parent when partially checked with lazyChildren', () => {
+      render(
+        <CheckboxTree
+          treeData={simpleTreeData}
+          checkedKeys={['0-0-0']}
+          lazyChildren
+        />
+      )
+
+      const documents = screen.getByLabelText('Documents')
+      expect(documents.closest('.ant-checkbox')).toHaveClass(
+        'ant-checkbox-indeterminate'
+      )
+    })
+
+    it('should not show an indeterminate parent by default (no lazyChildren)', () => {
+      render(<CheckboxTree treeData={simpleTreeData} checkedKeys={['0-0-0']} />)
+
+      const documents = screen.getByLabelText('Documents')
+      expect(documents.closest('.ant-checkbox')).not.toHaveClass(
+        'ant-checkbox-indeterminate'
+      )
+    })
+  })
 })

--- a/src/components/checkboxTree/__tests__/utils.test.ts
+++ b/src/components/checkboxTree/__tests__/utils.test.ts
@@ -2,6 +2,7 @@ import {
   getLeafKeys,
   getAllLeafKeys,
   isNodeChecked,
+  isNodeIndeterminate,
   getAllParentKeys,
 } from '../utils'
 import { CheckboxTreeDataNode } from '../CheckboxTree'
@@ -131,6 +132,62 @@ describe('isNodeChecked', () => {
 
   it('should return false for a parent with no leaf states', () => {
     expect(isNodeChecked(nestedTree[0], {})).toBe(false)
+  })
+})
+
+describe('isNodeIndeterminate', () => {
+  const allChecked: Record<string, boolean> = {
+    '0-0-0': true,
+    '0-0-1': true,
+    '0-1-0': true,
+    '0-1-1': true,
+    '1-0': true,
+    '1-1': true,
+  }
+
+  const someChecked: Record<string, boolean> = {
+    '0-0-0': true,
+    '0-0-1': false,
+    '0-1-0': true,
+    '0-1-1': true,
+    '1-0': false,
+    '1-1': false,
+  }
+
+  it('should return false for a leaf node', () => {
+    expect(
+      isNodeIndeterminate({ key: '0-0-0', title: 'Project A' }, someChecked)
+    ).toBe(false)
+  })
+
+  it('should return true when only some leaf descendants are checked', () => {
+    expect(isNodeIndeterminate(nestedTree[0], someChecked)).toBe(true)
+  })
+
+  it('should return false when all leaf descendants are checked', () => {
+    expect(isNodeIndeterminate(nestedTree[0], allChecked)).toBe(false)
+  })
+
+  it('should return false when no leaf descendants are checked', () => {
+    expect(isNodeIndeterminate(nestedTree[1], someChecked)).toBe(false)
+  })
+
+  it('should return true for a partially-checked nested parent', () => {
+    // Projects subtree: 0-0-0 checked, 0-0-1 unchecked in someChecked
+    expect(isNodeIndeterminate(nestedTree[0].children![0], someChecked)).toBe(
+      true
+    )
+  })
+
+  it('should return false for a fully-checked nested parent', () => {
+    // Reports subtree: 0-1-0 and 0-1-1 both checked in someChecked
+    expect(isNodeIndeterminate(nestedTree[0].children![1], someChecked)).toBe(
+      false
+    )
+  })
+
+  it('should return false for a parent with no leaf states', () => {
+    expect(isNodeIndeterminate(nestedTree[0], {})).toBe(false)
   })
 })
 

--- a/src/components/checkboxTree/__tests__/utils.test.ts
+++ b/src/components/checkboxTree/__tests__/utils.test.ts
@@ -2,7 +2,7 @@ import {
   getLeafKeys,
   getAllLeafKeys,
   isNodeChecked,
-  isNodeIndeterminate,
+  getNodeCheckState,
   getAllParentKeys,
 } from '../utils'
 import { CheckboxTreeDataNode } from '../CheckboxTree'
@@ -135,7 +135,7 @@ describe('isNodeChecked', () => {
   })
 })
 
-describe('isNodeIndeterminate', () => {
+describe('getNodeCheckState', () => {
   const allChecked: Record<string, boolean> = {
     '0-0-0': true,
     '0-0-1': true,
@@ -154,40 +154,60 @@ describe('isNodeIndeterminate', () => {
     '1-1': false,
   }
 
-  it('should return false for a leaf node', () => {
+  it('should report a checked leaf', () => {
     expect(
-      isNodeIndeterminate({ key: '0-0-0', title: 'Project A' }, someChecked)
-    ).toBe(false)
+      getNodeCheckState({ key: '0-0-0', title: 'Project A' }, someChecked)
+    ).toEqual({ checked: true, indeterminate: false })
   })
 
-  it('should return true when only some leaf descendants are checked', () => {
-    expect(isNodeIndeterminate(nestedTree[0], someChecked)).toBe(true)
+  it('should report an unchecked leaf', () => {
+    expect(
+      getNodeCheckState({ key: '0-0-1', title: 'Project B' }, someChecked)
+    ).toEqual({ checked: false, indeterminate: false })
   })
 
-  it('should return false when all leaf descendants are checked', () => {
-    expect(isNodeIndeterminate(nestedTree[0], allChecked)).toBe(false)
+  it('should report a fully-checked parent as checked', () => {
+    expect(getNodeCheckState(nestedTree[0], allChecked)).toEqual({
+      checked: true,
+      indeterminate: false,
+    })
   })
 
-  it('should return false when no leaf descendants are checked', () => {
-    expect(isNodeIndeterminate(nestedTree[1], someChecked)).toBe(false)
+  it('should report a partially-checked parent as indeterminate', () => {
+    expect(getNodeCheckState(nestedTree[0], someChecked)).toEqual({
+      checked: false,
+      indeterminate: true,
+    })
   })
 
-  it('should return true for a partially-checked nested parent', () => {
+  it('should report an unchecked parent as neither', () => {
+    expect(getNodeCheckState(nestedTree[1], someChecked)).toEqual({
+      checked: false,
+      indeterminate: false,
+    })
+  })
+
+  it('should report a partially-checked nested parent as indeterminate', () => {
     // Projects subtree: 0-0-0 checked, 0-0-1 unchecked in someChecked
-    expect(isNodeIndeterminate(nestedTree[0].children![0], someChecked)).toBe(
-      true
-    )
+    expect(getNodeCheckState(nestedTree[0].children![0], someChecked)).toEqual({
+      checked: false,
+      indeterminate: true,
+    })
   })
 
-  it('should return false for a fully-checked nested parent', () => {
+  it('should report a fully-checked nested parent as checked', () => {
     // Reports subtree: 0-1-0 and 0-1-1 both checked in someChecked
-    expect(isNodeIndeterminate(nestedTree[0].children![1], someChecked)).toBe(
-      false
-    )
+    expect(getNodeCheckState(nestedTree[0].children![1], someChecked)).toEqual({
+      checked: true,
+      indeterminate: false,
+    })
   })
 
-  it('should return false for a parent with no leaf states', () => {
-    expect(isNodeIndeterminate(nestedTree[0], {})).toBe(false)
+  it('should report neither for a parent with no leaf states', () => {
+    expect(getNodeCheckState(nestedTree[0], {})).toEqual({
+      checked: false,
+      indeterminate: false,
+    })
   })
 })
 

--- a/src/components/checkboxTree/__tests__/utils.test.ts
+++ b/src/components/checkboxTree/__tests__/utils.test.ts
@@ -1,7 +1,6 @@
 import {
   getLeafKeys,
   getAllLeafKeys,
-  isNodeChecked,
   getNodeCheckState,
   getAllParentKeys,
 } from '../utils'
@@ -83,55 +82,6 @@ describe('getAllLeafKeys', () => {
 
   it('should return empty array for empty input', () => {
     expect(getAllLeafKeys([])).toEqual([])
-  })
-})
-
-describe('isNodeChecked', () => {
-  const allChecked: Record<string, boolean> = {
-    '0-0-0': true,
-    '0-0-1': true,
-    '0-1-0': true,
-    '0-1-1': true,
-    '1-0': true,
-    '1-1': true,
-  }
-
-  const someChecked: Record<string, boolean> = {
-    '0-0-0': true,
-    '0-0-1': false,
-    '0-1-0': true,
-    '0-1-1': true,
-    '1-0': false,
-    '1-1': false,
-  }
-
-  it('should return true for a checked leaf', () => {
-    expect(
-      isNodeChecked({ key: '0-0-0', title: 'Project A' }, allChecked)
-    ).toBe(true)
-  })
-
-  it('should return false for an unchecked leaf', () => {
-    expect(
-      isNodeChecked({ key: '0-0-1', title: 'Project B' }, someChecked)
-    ).toBe(false)
-  })
-
-  it('should return true when all leaf descendants are checked', () => {
-    expect(isNodeChecked(nestedTree[0], allChecked)).toBe(true)
-  })
-
-  it('should return false when some leaf descendants are unchecked', () => {
-    expect(isNodeChecked(nestedTree[0], someChecked)).toBe(false)
-  })
-
-  it('should return true for a parent subtree with all leaves checked', () => {
-    // Reports subtree: 0-1-0 and 0-1-1 are both true in someChecked
-    expect(isNodeChecked(nestedTree[0].children![1], someChecked)).toBe(true)
-  })
-
-  it('should return false for a parent with no leaf states', () => {
-    expect(isNodeChecked(nestedTree[0], {})).toBe(false)
   })
 })
 

--- a/src/components/checkboxTree/utils.ts
+++ b/src/components/checkboxTree/utils.ts
@@ -43,6 +43,20 @@ export const isNodeChecked = (
   )
 }
 
+export const isNodeIndeterminate = (
+  node: CheckboxTreeDataNode,
+  leafNodeStates: Record<string | number, boolean>
+): boolean => {
+  if (!node.children || node.children.length === 0) {
+    return false
+  }
+  const leafKeys = getLeafKeys(node)
+  const checkedCount = leafKeys.filter(
+    (key) => leafNodeStates[key] === true
+  ).length
+  return checkedCount > 0 && checkedCount < leafKeys.length
+}
+
 export const getAllParentKeys = (
   nodes: CheckboxTreeDataNode[]
 ): (string | number)[] => {

--- a/src/components/checkboxTree/utils.ts
+++ b/src/components/checkboxTree/utils.ts
@@ -27,22 +27,6 @@ export const getAllLeafKeys = (
   return keys
 }
 
-export const isNodeChecked = (
-  node: CheckboxTreeDataNode,
-  leafNodeStates: Record<string | number, boolean>
-): boolean => {
-  if (!node.children || node.children.length === 0) {
-    // Leaf node - check if it's checked
-    return leafNodeStates[node.key] === true
-  }
-
-  // Parent node - check if all leaf descendants are checked
-  const leafKeys = getLeafKeys(node)
-  return (
-    leafKeys.length > 0 && leafKeys.every((key) => leafNodeStates[key] === true)
-  )
-}
-
 export const getNodeCheckState = (
   node: CheckboxTreeDataNode,
   leafNodeStates: Record<string | number, boolean>

--- a/src/components/checkboxTree/utils.ts
+++ b/src/components/checkboxTree/utils.ts
@@ -43,13 +43,10 @@ export const isNodeChecked = (
   )
 }
 
-export const isNodeIndeterminate = (
+export const getNodeCheckState = (
   node: CheckboxTreeDataNode,
   leafNodeStates: Record<string | number, boolean>
-): boolean => {
-  if (!node.children || node.children.length === 0) {
-    return false
-  }
+): { checked: boolean; indeterminate: boolean } => {
   let hasChecked = false
   let hasUnchecked = false
   const visit = (current: CheckboxTreeDataNode): boolean => {
@@ -64,7 +61,10 @@ export const isNodeIndeterminate = (
     return current.children.some(visit)
   }
   visit(node)
-  return hasChecked && hasUnchecked
+  return {
+    checked: hasChecked && !hasUnchecked,
+    indeterminate: hasChecked && hasUnchecked,
+  }
 }
 
 export const getAllParentKeys = (

--- a/src/components/checkboxTree/utils.ts
+++ b/src/components/checkboxTree/utils.ts
@@ -50,11 +50,21 @@ export const isNodeIndeterminate = (
   if (!node.children || node.children.length === 0) {
     return false
   }
-  const leafKeys = getLeafKeys(node)
-  const checkedCount = leafKeys.filter(
-    (key) => leafNodeStates[key] === true
-  ).length
-  return checkedCount > 0 && checkedCount < leafKeys.length
+  let hasChecked = false
+  let hasUnchecked = false
+  const visit = (current: CheckboxTreeDataNode): boolean => {
+    if (!current.children || current.children.length === 0) {
+      if (leafNodeStates[current.key] === true) {
+        hasChecked = true
+      } else {
+        hasUnchecked = true
+      }
+      return hasChecked && hasUnchecked
+    }
+    return current.children.some(visit)
+  }
+  visit(node)
+  return hasChecked && hasUnchecked
 }
 
 export const getAllParentKeys = (


### PR DESCRIPTION
## What
Adds an opt-in `lazyChildren` prop to `CheckboxTree`.

When `lazyChildren` is set:
- a node's children are mounted only while it is expanded (collapsed nodes render nothing)
- partially-checked parents render as `indeterminate`

The prop defaults to `false`, so every existing consumer keeps the current always-mounted, all-or-nothing behavior.

## Why
With the default tree, collapsing a node only hides its children via CSS — they stay mounted. For a large tree (e.g. all US states × their counties, ~4000 leaves) that means thousands of checkboxes are mounted up front, which blocks the main thread. `lazyChildren` lets a consumer keep the tree collapsed and mount each node's children only on demand.

## How
- `TreeNode` gates the children render on `(!lazyChildren || isExpanded)` and sets the checkbox `indeterminate` (only when `lazyChildren` is on).
- New `getNodeCheckState(node, leafNodeStates)` util returns `{ checked, indeterminate }` from a single short-circuiting traversal (no per-node `getLeafKeys` allocation). It replaces the earlier `isNodeChecked` / `isNodeIndeterminate` helpers, which have been removed.
- `CheckboxTree.handleCheck` builds `checkedLeafNodes` / `allCheckedNodes` in one post-order traversal (previously called `isNodeChecked` per node, which was near-quadratic on large trees), and now includes `leafNodeValues` in its `useCallback` deps (fixes a stale-snapshot bug where consecutive checks could drop earlier ones in uncontrolled mode).
- `CheckboxTree` threads `lazyChildren` through to `TreeNode`; default `false`.

## Testing
- `getNodeCheckState` unit tests (leaf / partial / full / empty / nested).
- `CheckboxTree` tests: collapsed children are not mounted with `lazyChildren`, are mounted on expand, stay mounted by default; indeterminate shows only with `lazyChildren`; consecutive checks are preserved in uncontrolled mode.
- Existing snapshot test still passes (default rendering unchanged).
- `vitest` (43 passed), `type-check`, `eslint`, `prettier` all clean.
- New `LazyChildren` Storybook story (6 states × 40 counties, collapsed, one state pre-partially-checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)