### PR TITLE
NAVY-1104: outlined radio button labels use primary blue

### DIFF
--- a/src/appTheme.ts
+++ b/src/appTheme.ts
@@ -233,6 +233,12 @@ export const appTheme: ThemeConfig = {
     Rate: {
       marginXS: 0,
     },
+    Radio: {
+      // Unselected outlined radio-button labels default to colorText (near-black);
+      // align them with the selected label's primary blue so the control reads as
+      // a single cohesive outlined-blue selector.
+      buttonColor: 'var(--j2-color-primary)',
+    },
     Select: {
       multipleItemBg: 'var(--j2-gray-2)',
       multipleItemBorderColor: 'var(--j2-gray-4)',


### PR DESCRIPTION
## What
Add a `Radio.buttonColor` theme token set to the primary blue, so **all** outlined radio-button option labels (selected *and* unselected) render in the same blue.

## Why
NAVY-1104 (follow-up to NAVY-1096 / j2 PR #2685, which switched the packet-builder selection controls to outlined button `RadioGroup`s).

Antd's outlined radio buttons color only the *selected* label with `colorPrimary` and leave *unselected* labels at `colorText` (near-black), so the control reads as a mix of blue and black text. The fix belongs in the design system tokens — not as ad-hoc overrides in consumer code — so every consumer of the outlined `RadioGroup` gets a cohesive outlined-blue selector.

## How
One token in `appTheme.ts → components.Radio`:

```ts
Radio: {
  buttonColor: 'var(--j2-color-primary)',
},
```

`buttonColor` is Antd's "color of Radio button text" (the unselected/base label color). Setting it to `--j2-color-primary` (`#253761`, `j2-blue-9`) matches the blue Antd already applies to the selected label. Outlined borders are unchanged (selected = blue, unselected = gray).

Scope notes:
- Only affects `optionType="button"` radios. Dot radios (`optionType="default"`) use `.ant-radio-wrapper` and are untouched.
- A *solid* button group's unselected label also becomes blue-on-white (selected stays white-on-blue). No solid button radios exist in j2 today; this only shows in the Solid Button story.

## Testing
- Verified in Storybook (Radio Group → Outline Button) via computed styles: selected and unselected labels are both `rgb(37,55,97)` = `#253761`; unselected border stays gray.
- `npm run lint`, `npm run type-check`, and the radio unit tests pass; the radio snapshot is unchanged (the token is CSS-in-JS, not DOM classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
